### PR TITLE
template: change Volt parsing

### DIFF
--- a/Volt.pm
+++ b/Volt.pm
@@ -19,7 +19,7 @@ sub extract {
     # Volt Template:
     $line = 1;
     pos($_) = 0;
-    while (m/\G(.*?(?<!\{)\{\{(?!\{)\s*lang\._\('(.*?)'\)\s*?\|?.*?\}\})/sg) {
+    while (m/\G(.*?(?<!\{)\{\{(?!\{).*?lang\._\('(.*?)'\).*?\|?.*?\}\})/sg) {
         my ( $vars, $str ) = ( '', $2 );
         $line += ( () = ( $1 =~ /\n/g ) );    # cryptocontext!
         $self->add_entry( $str, $line, $vars );


### PR DESCRIPTION
Current processed only string, like this:
`{{ lang._('Enabled') }}`
But string, like this, don't processed:
`{{ partial("layout_partials/base_dialog",['fields':formDialogWhitelist,'id':'DialogWhitelist','label':lang._('Edit rule')])}}`
This patch add this feature.