### PR TITLE
 Update de_DE.po 

### DIFF
--- a/de_DE.po
+++ b/de_DE.po
@@ -14076,7 +14076,7 @@ msgstr "Konfiguration ändern"
 
 # File: src/www/firewall_rules.php, line: 291
 msgid "Block all IPv6 traffic"
-msgstr "Blockiere gesammten IPv6 Datenverkehr"
+msgstr "Blockiere IPv6 Datenverkehr"
 
 msgid ""
 "The firewall rule configuration has been changed.<br />You must apply the "


### PR DESCRIPTION
Unfortunately, the German translation of " Block all IPv6 traffic ( Blockiere gesammten IPv6 Datenverkehr ) " ( line 14077 - 14079 ) is too long for the rules table , so all rules are displayed in 2 lines.