### PR TITLE
HTML escape.

### DIFF
--- a/scripts/plugins/config.py
+++ b/scripts/plugins/config.py
@@ -45,4 +45,4 @@ def getTranslations(root):
                 for item in childNode:
                     for itemTags in item:
                         if itemTags.tag == "descr":
-                            yield itemTags.text
+                            yield itemTags.text.replace("'", "&#039;")


### PR DESCRIPTION
Don't translate string
`Randomize PID's (see src/sys/kern/kern_fork.c: sysctl_kern_randompid())`