### PR TITLE
I guess this is better Japanese translation of "Prefer IPv4 over IPv6"

### DIFF
--- a/ja_JP.po
+++ b/ja_JP.po
@@ -2656,7 +2656,7 @@ msgid "Prefer to use IPv4 even if IPv6 is available"
 msgstr "IPv6 が利用可能でも IPv4 の使用を優先"
 
 msgid "Prefer IPv4 over IPv6"
-msgstr "IPv4 over IPv6 を優先"
+msgstr "IPv6 より IPv4 を優先"
 
 msgid "Networking"
 msgstr "ネットワーキング"


### PR DESCRIPTION
Hi,

Here is translation of "Prefer IPv4 over IPv6": it is not a technology called "IPv4 over IPv6" which sounds like tunnel, rather this is just preferring IPv4 better than IPv6.

I felt this makes less misunderstanding, how do you think about it?

Or may be it is more simple to write "IPv4 を優先".

If some other Japanese agree, I'm glad if it is merged.