### PR TITLE
fix(zh_CN.po): Missing placeholder %s causes an exception in the Chin…

### DIFF
--- a/zh_CN.po
+++ b/zh_CN.po
@@ -56596,7 +56596,7 @@ msgstr "Adaptive.start 和 Adaptive.end 值（高级选项）必须配置为非�
 #. File: /usr/core/src/www/guiconfig.inc, line: 295
 #: 
 msgid "The changes have been applied successfully, remember to update your backup server in %sSystem: High availability: status%s"
-msgstr "更改已成功应用，请记住更新%系统：高可用性：状态%s中的备份服务器"
+msgstr "更改已成功应用，请记住更新%s系统：高可用性：状态%s中的备份服务器"
 
 #. File: /usr/core/src/opnsense/mvc/app/models/OPNsense/Interfaces/Vlan.php, line: 68
 #: 


### PR DESCRIPTION
Missing placeholder %s causes an exception in the Chinese interface


[issues](https://github.com/opnsense/lang/issues/70)