### PR TITLE
lang: update German

### DIFF
--- a/de_DE.po
+++ b/de_DE.po
@@ -69239,7 +69239,7 @@ msgstr "LOCK"
 #. File: /usr/lang/src/models.php, line: 1072
 #: 
 msgid "Leases DHCPv6"
-msgstr "DHCPv6-Leases"
+msgstr "Leases DHCPv6"
 
 #. File: /usr/lang/src/models.php, line: 1089
 #: 


### PR DESCRIPTION
Change translation to have the same wording for DHCPv4 and DHCPv6 Leases